### PR TITLE
add corrected perplexity logging for every n steps

### DIFF
--- a/model/nlp/baseline_transformer.py
+++ b/model/nlp/baseline_transformer.py
@@ -63,8 +63,13 @@ class Baseline_Transformer_NLP(L.LightningModule):
         cce_loss = F.nll_loss(predicted_distribution, next_token_indices, ignore_index=self.tokenizer_pad_token_id)
         ppl_loss = torch.exp(cce_loss).detach()
 
+        # Count non-padded tokens for accurate perplexity calculation
+        num_tokens = (next_token_indices != self.tokenizer_pad_token_id).sum().item()
+
         log_dict = {
             'loss': cce_loss,
-            'perplexity': ppl_loss
+            'perplexity': ppl_loss,
+            'batch_total_loss': cce_loss * num_tokens,  # For accurate perplexity
+            'batch_num_tokens': num_tokens  # For accurate perplexity
         }
         return log_dict

--- a/model/nlp/ebt.py
+++ b/model/nlp/ebt.py
@@ -233,13 +233,18 @@ class EBT_NLP(L.LightningModule):
             total_loss = self.hparams.reconstruction_coeff * reconstruction_loss
             contrastive_loss = 0.0
 
+        # Count non-padded tokens for accurate perplexity calculation
+        num_tokens = (next_token_indices != self.tokenizer_pad_token_id).sum().item()
+        
         log_dict = {
             'loss': total_loss,
             'initial_loss' : initial_loss,
             'final_step_loss': final_reconstruction_loss,
             'contrastive_loss' : contrastive_loss,
             'initial_final_pred_energies_gap': initial_final_pred_energies_gap,
-            'perplexity': ppl_loss
+            'perplexity': ppl_loss,
+            'batch_total_loss': final_reconstruction_loss * num_tokens,  # For accurate perplexity
+            'batch_num_tokens': num_tokens  # For accurate perplexity
         }
         return log_dict
     


### PR DESCRIPTION
quick pr that fixes the agglomerated perplexity calculation on NLP runs so that the Jensen's inequality issue doesn't crop up. I'm pretty sure that you can directly compare the output from my added logic with the (incorrect) averaging of exponentiated batch/step perplexities I'm ASSUMING lightning does automatically every N steps under the hood.

I'll take it out of draft once I'm finished testing. Very cool paper!