### PR TITLE
[PR] fix: correct ImageNet dataloader (resolves #10)

### DIFF
--- a/data/img/imagenet_dataloader.py
+++ b/data/img/imagenet_dataloader.py
@@ -3,6 +3,7 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 import getpass
 from torchvision import transforms
+import os
 
 #credit: https://huggingface.co/datasets/imagenet-1k'
 #NOTE: if you are having issues with this dataloader and perms you need to add your HF token
@@ -11,10 +12,38 @@ class ImageNetDataset(Dataset):
     def __init__(self, hparams, split, transform):
         self.hparams = hparams
         self.transform = transform
-        current_user = getpass.getuser()
+        # current_user = getpass.getuser()
         split = 'validation' if split in ["valid", "val", "validate"] else split
-        dataset_dir = self.hparams.dataset_dir if self.hparams.dataset_dir != "" else f"/scratch/{current_user}/imagenet/"
-        self.ds = load_dataset("imagenet-1k", cache_dir = dataset_dir, trust_remote_code=True, split=split)
+        
+        hf_home = os.getenv('HF_HOME')
+        dataset_dir = self.hparams.dataset_dir if self.hparams.dataset_dir != "" else hf_home
+        
+        hf_token = os.getenv('HF_TOKEN')
+        if not hf_token:
+            print("warning: HF_TOKEN not set. you may need authentication for ImageNet access.")
+        
+        # print(f"loading ImageNet from cache: {dataset_dir if dataset_dir else 'HF default'}")
+        
+        self.ds = load_dataset(
+            "ILSVRC/imagenet-1k", 
+            cache_dir=dataset_dir,
+            token=hf_token,
+            trust_remote_code=True, 
+            split=split,
+            verification_mode='no_checks',
+            num_proc=min(12, os.cpu_count()) 
+        )
+        
+        print(f"ImageNet {split} dataset loaded with {len(self.ds)} samples")
+        try:
+            sample0 = self.ds[0]
+            img0 = sample0['image']
+            if img0.mode == 'L' or img0.mode == 'RGBA':
+                img0 = img0.convert("RGB")
+            t0 = self.transform(img0)
+            print(f"sample transformed image shape: {t0.shape}")
+        except Exception as e:
+            print(f"shape check error: {e}")
 
     def __len__(self):
         return len(self.ds)
@@ -29,9 +58,4 @@ class ImageNetDataset(Dataset):
             image = image.convert("RGB")
         
         transformed_image = self.transform(image)
-        data_dict = {
-            'transformed_images' : transformed_image,
-            'labels' : sample['label']
-        }
-        return data_dict
-
+        return {'image': transformed_image, 'label': sample['label']}

--- a/data/img/imagenet_dataloader.py
+++ b/data/img/imagenet_dataloader.py
@@ -35,15 +35,6 @@ class ImageNetDataset(Dataset):
         )
         
         print(f"ImageNet {split} dataset loaded with {len(self.ds)} samples")
-        try:
-            sample0 = self.ds[0]
-            img0 = sample0['image']
-            if img0.mode == 'L' or img0.mode == 'RGBA':
-                img0 = img0.convert("RGB")
-            t0 = self.transform(img0)
-            print(f"sample transformed image shape: {t0.shape}")
-        except Exception as e:
-            print(f"shape check error: {e}")
 
     def __len__(self):
         return len(self.ds)


### PR DESCRIPTION
fix: correct imagenet dataloader - resolves #10

1. sets download dir to HF_HOME by default unless specified otherwise. (recommendation: set the HF_HOME to a permanent location with sufficient storage)
2. load_dataset 
   - downloads from "ILSVRC/imagenet-1k"
   - passes hf_token directly
   - uses multiple workers if available
3. IMPORTANT: returns the correct label for the transformed imgs ('image' instead of 'transformed_images') as expected by the rest of the codebase.